### PR TITLE
Connection options

### DIFF
--- a/lib/jerk.js
+++ b/lib/jerk.js
@@ -22,17 +22,24 @@ var Jerk = new ( function Jerk() {
   }
 
   /* ------------------------------ Private Methods ------------------------------ */
-  function _connect( options ) { var i
+  function _connect( options ) {
+    var i
     bot = new IRC( options || {} )
     bot
       .addListener( 'privmsg', _receive_message.bind( this ) )
-      .connect( function(){
-        setTimeout( function() {
-          // Join channels
-          if ( Array.isArray( bot.options.channels ) )
-            for ( i = 0; i < bot.options.channels.length; i++ )
-              this.join( bot.options.channels[i] )
-        }.bind( this ), 15000 )
+      .connect( function() {
+        bot.listenOnce("ping", function() {
+          setTimeout( function() {
+            // Join channels
+            if ( Array.isArray( bot.options.channels ) )
+              for ( i = 0; i < bot.options.channels.length; i++ )
+                this.join( bot.options.channels[i] )
+
+            // Call onConnect callback
+            if (options.onConnect)
+              options.onConnect.call();
+          }.bind( this ), options.delayAfterConnect || 15000 )
+        });
       })
     
     return { say:     _privmsg_protected.bind( this )


### PR DESCRIPTION
- make the post-connection delay optionally configurable
- make connection detection more deterministic (slightly) by listening for ping event
- add an optional onConnect callback

if you want to use Jerk to do things that aren't channel activity responses, such as a bot that pushes content to a channel, things were all fail-y. this set of changes makes it super easy to make a bot that connects, and on a successful connection, starts doing stuff.
