### PR TITLE
Added `joinOn` option, which takes a raw IRC protocol code and triggers the on-connect stuff (much better than waiting for ping)

### DIFF
--- a/lib/jerk.js
+++ b/lib/jerk.js
@@ -51,6 +51,8 @@ Jerk = new ( function Jerk() {
   function _on_connect() {
     if ( this.options.waitForPing )
       this.once( 'ping', justDoIt )
+    else if ( this.options.joinOn )
+      this.once( this.options.joinOn, justDoIt )
     else
       justDoIt.call( this )
 


### PR DESCRIPTION
Added an additional 'trigger on-connect' override called `joinOn`, which accepts a raw IRC protocol code
