### PR TITLE
Expose `person` object to watcher hollabacks

### DIFF
--- a/lib/jerk.js
+++ b/lib/jerk.js
@@ -190,6 +190,7 @@ Jerk = new ( function Jerk() {
       , msg:        _privmsg_protected.bind( this, message.person.nick )
       , match_data: md || []
       , user:       message.person.nick
+      , person:     message.person
       , source:     source
       , text:       message.params.slice( -1 )
       , toString:   _to_string


### PR DESCRIPTION
Since there's _no_ way of getting this information today, this would be a nice addition and doesn't interfere with existing properties.
