### PR TITLE
Use util instead of sys in example.

### DIFF
--- a/examples/simple.js
+++ b/examples/simple.js
@@ -1,4 +1,4 @@
-var jerk = require( '../lib/jerk' ), sys=require('sys');
+var jerk = require( '../lib/jerk' ), util = require('util');
 var options =
   { server: 'localhost'
   , port: 6667
@@ -20,7 +20,7 @@ jerk( function( j ) {
   });
 
   j.user_leave(function(message) {
-    sys.puts("User: " + message.user + " has left");
+    util.puts("User: " + message.user + " has left");
   });
 }).connect( options );
 


### PR DESCRIPTION
Make sure the example Jerk script continues to work in future node.js
releases. The node.js `sys` library has been a pointer to `util` since
0.3 and has now been removed completely in the node.js development
branch.
