### PR TITLE
Message source is now a Channel

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ The jerk object (`j`) has only one method: `watch_for`. Which takes two argument
 
 ```javascript
 { user:       String
-, source:     String
+, source:     Channel
 , match_data: Array
 , say:        Function( message )
 , msg:        Function( message )
@@ -64,6 +64,8 @@ The jerk object (`j`) has only one method: `watch_for`. Which takes two argument
 ```
 
 One thing I will tell you though, is the `say` method is smart enough to reply to the context that the message was received, so you don't need to pass it any extra info, just a reply :) However, the `msg` method can be used if you'd like to force sending a message directly to a user (aka a PM).
+
+Cast `source` to a string to return the channel name. You can also work out who is in a channel by iterating over `source.clients`.
 
 The `connect` method returns an object with some handy methods that you can use outside of your `watch_for`s:
 

--- a/examples/source.js
+++ b/examples/source.js
@@ -1,0 +1,21 @@
+var jerk = require( '../lib/jerk' ), util = require('util');
+var options =
+  { server: 'localhost'
+  , port: 6667
+  , nick: 'Bot9121'
+  , channels: [ '#jerkbot' ]
+  };
+
+jerk( function( j ) {
+  j.watch_for( 'cake', function( message ) {
+    var out = 'Cake is a lie!'
+      , channel = message.source;
+    for ( client in channel.clients ) {
+      if ( 'GlaDOS' == channel.clients[client] ) {
+        out = 'psst, I have something to tell you but I can\'t say it while GlaDOS is in ' + String(channel);
+      }
+    }
+    message.say( message.user + ': ' + out );
+  });
+}).connect( options );
+


### PR DESCRIPTION
Describe `message.source` based on the current code; it's not a String any more. Also include an example.
